### PR TITLE
Added Laradock

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,10 +6,10 @@ APP_LOG_LEVEL=debug
 APP_URL=http://localhost
 
 DB_CONNECTION=mysql
-DB_HOST=127.0.0.1
+DB_HOST=mariadb # (localhost|mariadb|mysql|IP address)
 DB_PORT=3306
-DB_DATABASE=homestead
-DB_USERNAME=homestead
+DB_DATABASE=default
+DB_USERNAME=default
 DB_PASSWORD=secret
 
 BROADCAST_DRIVER=log
@@ -32,12 +32,11 @@ PUSHER_APP_ID=
 PUSHER_APP_KEY=
 PUSHER_APP_SECRET=
 
-AUTH_CLIENT_ID=some_client_id
-AUTH_CLIENT_SECRET=some_client_secret
-AUTH_PROXY_BASE_URL=http://localhost/path/to/laravel
+AUTH_CLIENT_ID=
+AUTH_CLIENT_SECRET=
+AUTH_PROXY_BASE_URL=http://localhost
 
-PASSWORD_RESET_BASE_URL=http://www.frontend.com/password/reset
+PASSWORD_RESET_BASE_URL=http://localhost/password/reset
 
-TEST_API_URL=http://localhost/path/to/laravel
+TEST_API_URL=http://localhost
 TEST_EMAIL=email@example.com
-

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "laradock"]
+	path = laradock
+	url = https://github.com/Laradock/laradock.git

--- a/readme.md
+++ b/readme.md
@@ -6,7 +6,9 @@ For this I will concentrate on using it as an API server.
 
 I make the assumption that you have a local environment for development seup already. If you don’t, I recommend MAMP or XAMMP. The Laravel docs list other options for you set up a local environment such as Homestead or Valet, your mileage may vary.
 
-* TLDR
+* Quickstart: Docker
+* Quickstart: TLDR
+
 * Installing Laravel
 * Setup and Configure Database
 * Installing and Configuring Passport
@@ -20,7 +22,43 @@ I make the assumption that you have a local environment for development seup alr
 * Deploy the Code to Heroku
 
 
-## TLDR
+## Quickstart: Docker
+
+[Docker](https://www.docker.com/), using [Laradock](http://laradock.io/).
+
+```bash
+git clone --recursive -j8 git@github.com:wonkenstein/laravel-api.git
+cd laravel-api/laradock
+docker-compose up -d nginx mariadb
+docker-compose exec --user=laradock workspace composer install
+docker-compose exec --user=laradock workspace cp .env.example .env
+docker-compose exec --user=laradock workspace php artisan key:generate
+docker-compose exec --user=laradock workspace php artisan migrate 
+docker-compose exec --user=laradock workspace php artisan db:seed --class=UsersTableSeeder
+docker-compose exec --user=laradock workspace php artisan passport:keys
+docker-compose exec --user=laradock workspace php artisan passport:client --password --name=laravel-api
+```
+
+Manually copy the generated **Client ID** and **Client Secret** values into the `.env` file, at: 
+
+```bash
+AUTH_CLIENT_ID=...
+AUTH_CLIENT_SECRET=...
+```
+
+_(**@todo** edit the `.env` file automatically, using e.g. sed)_
+
+Finally, run the **Unit Tests**:
+
+```bash
+docker-compose exec --user=laradock workspace php ./vendor/bin/phpunit
+# cURL error 7: Failed to connect to localhost port 80: Connection refused
+# It's possibly a Docker network traffic restriction issue that should be fixed.
+```
+
+_This install could be reduced to a few lines of code as most of the commands could be scripted, using something like [Docker Sync](https://github.com/EugenMayer/docker-sync/wiki/7.-Scripting-with-docker-sync) or a `.sh` script._
+
+## Quickstart: TLDR
 
 If don't want to read all of this and just want to get this running, follow the steps below. Otherwise go to [Installing Laravel](#installing-laravel)
 


### PR DESCRIPTION
I added a Docker config which you might find useful too:

- Added Laradock as a Git submodule. Use the `--recursive` flag when cloning, or something like `git submodule update`.
- Updated `.env-default` to match the default Laradock db credentials & http://localhost/ URL, reducing the amount of file edits needed to get a Docker environment running.
- Added **Quickstart: Docker** to the README.

The homepage displays OK, but I can't get `phpunit` to work yet. I think that's a Docker network config issue I'll try to fix. 

For:
```bash
docker-compose exec --user=laradock workspace php ./vendor/bin/phpunit
```

I get:
```bash
cURL error 7: Failed to connect to localhost port 80: Connection refused
```